### PR TITLE
refactor(workers): remove unused login function and related types

### DIFF
--- a/intelligent-logistics-frontend/src/components/gate-operator/Dashboard.tsx
+++ b/intelligent-logistics-frontend/src/components/gate-operator/Dashboard.tsx
@@ -10,9 +10,13 @@ import { getGateWebSocket, type DecisionUpdatePayload } from "@/lib/websocket";
 import { ToastNotifications, useToasts } from "@/components/common/ToastNotifications";
 import type { Appointment } from "@/types/types";
 
-// Extended Appointment type with highway_infraction property
+// Extended Appointment type with all orthogonal state flags
 interface ExtendedAppointment extends Appointment {
   highway_infraction?: boolean;
+  is_delayed?: boolean;
+  is_unloading?: boolean;
+  primary_status?: string;
+  display_status?: string;
 }
 
 // Map API status to English display
@@ -69,6 +73,7 @@ function generateUniqueId(prefix: string): string {
 
 // Map API arrival to UI format  
 function mapArrivalToUI(arrival: ExtendedAppointment) {
+  const primaryStatus = arrival.primary_status ?? arrival.status;
   return {
     id: String(arrival.id),
     plate: arrival.truck_license_plate,
@@ -77,7 +82,10 @@ function mapArrivalToUI(arrival: ExtendedAppointment) {
       : "--:--",
     cargo: arrival.booking?.reference || "N/A",
     cargoAmount: arrival.notes || "",
-    status: mapStatusToLabel(arrival.status) as string,
+    status: mapStatusToLabel(arrival.status) as string,        // display_status (compat)
+    primaryStatus: mapStatusToLabel(primaryStatus) as string,  // primary for new badge
+    isDelayed: arrival.is_delayed ?? arrival.status === "delayed",
+    isUnloading: arrival.is_unloading ?? arrival.status === "unloading",
     dock: arrival.gate_in?.label || "N/A",
     highwayInfraction: arrival.highway_infraction || false,
   };
@@ -916,12 +924,18 @@ export default function Dashboard() {
                     <div className="header-status">
                       <span className="status-badge-wrapper" style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '0.4rem' }}>
                         <span
-                          className={`status-badge status-${arrival.status
+                          className={`status-badge status-${(arrival.primaryStatus ?? arrival.status)
                             .toLowerCase()
                             .replace(/\s/g, "-")}`}
                         >
-                          {arrival.status}
+                          {arrival.primaryStatus ?? arrival.status}
                         </span>
+                        {arrival.isDelayed && (
+                          <span className="status-badge status-delayed-substate">Delayed</span>
+                        )}
+                        {arrival.isUnloading && (
+                          <span className="status-badge status-unloading-substate">Unloading</span>
+                        )}
                         {arrival.highwayInfraction && (
                           <span className="status-badge status-highway-infraction">
                             Infraction

--- a/intelligent-logistics-frontend/src/components/layout/gate-operator/operator-layout.css
+++ b/intelligent-logistics-frontend/src/components/layout/gate-operator/operator-layout.css
@@ -1773,6 +1773,7 @@ html {
   font-weight: 700;
 }
 
+
 /* Portuguese status classes (legacy) */
 .status-badge.status-pendente {
   background: var(--badge-warning-bg);

--- a/intelligent-logistics-frontend/src/components/layout/shared/theme-base.css
+++ b/intelligent-logistics-frontend/src/components/layout/shared/theme-base.css
@@ -336,3 +336,18 @@
   font-size: 0.75rem;
   font-weight: 600;
 }
+
+/* Sub-state badges — shown alongside the primary status badge */
+.status-badge.status-delayed-substate {
+  background: rgba(234, 179, 8, 0.12);
+  color: #FDE047;
+  border: 1px dashed rgba(234, 179, 8, 0.5);
+  font-size: 0.7rem;
+}
+
+.status-badge.status-unloading-substate {
+  background: rgba(59, 130, 246, 0.12);
+  color: #93C5FD;
+  border: 1px dashed rgba(59, 130, 246, 0.45);
+  font-size: 0.7rem;
+}

--- a/intelligent-logistics-frontend/src/pages/gate-operator/ArrivalDetail.tsx
+++ b/intelligent-logistics-frontend/src/pages/gate-operator/ArrivalDetail.tsx
@@ -116,7 +116,19 @@ export default function ArrivalDetail() {
             <Row label="Reference"      value={appointment.booking_reference} />
             <Row
               label="Status"
-              value={statusLabel(appointment.status)}
+              value={
+                <span style={{ display: 'inline-flex', flexWrap: 'wrap', gap: '4px' }}>
+                  <span className={`status-badge status-${((appointment as any).primary_status ?? appointment.status).toLowerCase().replace(/\s/g, '-')}`}>
+                    {statusLabel((appointment as any).primary_status ?? appointment.status)}
+                  </span>
+                  {((appointment as any).is_delayed ?? appointment.status === 'delayed') && (
+                    <span className="status-badge status-delayed-substate">Delayed</span>
+                  )}
+                  {((appointment as any).is_unloading ?? appointment.status === 'unloading') && (
+                    <span className="status-badge status-unloading-substate">Unloading</span>
+                  )}
+                </span>
+              }
             />
             <Row
               label="Scheduled"

--- a/intelligent-logistics-frontend/src/pages/gate-operator/ArrivalsList.tsx
+++ b/intelligent-logistics-frontend/src/pages/gate-operator/ArrivalsList.tsx
@@ -60,9 +60,12 @@ type UIArrival = {
   dock: string;
   arrivalTime: string;
   cargo: string;
-  status: string;
+  status: string;           // display_status label (compat)
+  primaryStatus: string;    // primary state label (never Delayed/Unloading)
   apiStatus: AppointmentStatusEnum;
   highwayInfraction?: boolean;
+  isDelayed?: boolean;
+  isUnloading?: boolean;
 };
 
 export const ITEMS_PER_PAGE = 10;
@@ -135,18 +138,24 @@ function ArrivalsList() {
   const gateId = rawGateId || "1";
 
   // Map API arrival to UI
-  const mapArrivalToUI = (arrival: Appointment): UIArrival => ({
-    id: arrival.id,
-    plate: arrival.truck_license_plate,
-    dock: arrival.gate_in?.label || "N/A",
-    arrivalTime: arrival.scheduled_start_time
-      ? new Date(arrival.scheduled_start_time).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })
-      : "--:--",
-    cargo: arrival.booking?.reference || "N/A",
-    status: arrival.status ? mapStatusToLabel(arrival.status) : "Unknown",
-    apiStatus: (arrival.status ?? "scheduled"),
-    highwayInfraction: arrival.highway_infraction || false,
-  });
+  const mapArrivalToUI = (arrival: Appointment): UIArrival => {
+    const primaryStatus = (arrival as any).primary_status ?? arrival.status;
+    return {
+      id: arrival.id,
+      plate: arrival.truck_license_plate,
+      dock: arrival.gate_in?.label || "N/A",
+      arrivalTime: arrival.scheduled_start_time
+        ? new Date(arrival.scheduled_start_time).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })
+        : "--:--",
+      cargo: arrival.booking?.reference || "N/A",
+      status: arrival.status ? mapStatusToLabel(arrival.status) : "Unknown",
+      primaryStatus: primaryStatus ? mapStatusToLabel(primaryStatus) : "Unknown",
+      apiStatus: (arrival.status ?? "scheduled"),
+      highwayInfraction: arrival.highway_infraction || false,
+      isDelayed: (arrival as any).is_delayed ?? arrival.status === "delayed",
+      isUnloading: (arrival as any).is_unloading ?? arrival.status === "unloading",
+    };
+  };
 
   // Fetch data function
   const fetchData = useCallback(async () => {
@@ -592,14 +601,20 @@ function ArrivalsList() {
                           <td>{arrival.arrivalTime}</td>
                           <td>{arrival.cargo}</td>
                           <td>
-                            <span className={`status-badge status-${(arrival.status || 'unknown').toLowerCase().replace(/\s/g, "-")}`}>
-                              {arrival.status || 'Unknown'}
-                            </span>
-                            {arrival.highwayInfraction && (
-                              <span className="status-badge status-highway-infraction" style={{ marginLeft: '4px' }}>
-                                Infraction
+                            <span style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', alignItems: 'center' }}>
+                              <span className={`status-badge status-${((arrival.primaryStatus || arrival.status) || 'unknown').toLowerCase().replace(/\s/g, "-")}`}>
+                                {arrival.primaryStatus || arrival.status || 'Unknown'}
                               </span>
-                            )}
+                              {arrival.isDelayed && (
+                                <span className="status-badge status-delayed-substate">Delayed</span>
+                              )}
+                              {arrival.isUnloading && (
+                                <span className="status-badge status-unloading-substate">Unloading</span>
+                              )}
+                              {arrival.highwayInfraction && (
+                                <span className="status-badge status-highway-infraction">Infraction</span>
+                              )}
+                            </span>
                           </td>
                           <td>
                             <button

--- a/intelligent-logistics-frontend/src/pages/logistics-manager/InfractionsPage.tsx
+++ b/intelligent-logistics-frontend/src/pages/logistics-manager/InfractionsPage.tsx
@@ -233,8 +233,16 @@ export default function InfractionsPage() {
                                             <td>{dateTime}</td>
                                             <td>{gate}</td>
                                             <td>
-                                                <span className={`status-badge ${statusBadgeClass(item.status)}`}>
-                                                    {statusLabel(item.status)}
+                                                <span style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+                                                    <span className={`status-badge ${statusBadgeClass((item as any).primary_status ?? item.status)}`}>
+                                                        {statusLabel((item as any).primary_status ?? item.status)}
+                                                    </span>
+                                                    {((item as any).is_delayed ?? item.status === 'delayed') && (
+                                                        <span className="status-badge status-delayed-substate">Delayed</span>
+                                                    )}
+                                                    {((item as any).is_unloading ?? item.status === 'unloading') && (
+                                                        <span className="status-badge status-unloading-substate">Unloading</span>
+                                                    )}
                                                 </span>
                                             </td>
                                         </tr>

--- a/intelligent-logistics-frontend/src/pages/logistics-manager/ManagerDashboard.tsx
+++ b/intelligent-logistics-frontend/src/pages/logistics-manager/ManagerDashboard.tsx
@@ -151,6 +151,8 @@ export default function ManagerDashboard() {
                 <KPICard
                     title="In Transit"
                     value={summary?.trucksInTransit ?? "--"}
+                    statusLabel={summary?.trucksInTransitDelayed ? `${summary.trucksInTransitDelayed} delayed` : undefined}
+                    status={summary?.trucksInTransitDelayed ? "warning" : undefined}
                     isLoading={summaryLoading}
                 />
                 <KPICard

--- a/intelligent-logistics-frontend/src/services/statistics.ts
+++ b/intelligent-logistics-frontend/src/services/statistics.ts
@@ -6,9 +6,10 @@ import api from '@/lib/api';
 
 export interface DashboardSummary {
     trucksInPort: number;
-    trucksInTransit: number;
+    trucksInTransit: number;          // on-time in_transit (not yet delayed)
+    trucksInTransitDelayed?: number;  // in_transit past scheduled time
     scheduledCount: number;
-    unloadingCount: number;
+    unloadingCount: number;           // in_process with active unloading Visit
     completedCount: number;
     entriesCount: number;
     exitsCount: number;

--- a/intelligent-logistics-frontend/src/services/workers.ts
+++ b/intelligent-logistics-frontend/src/services/workers.ts
@@ -4,8 +4,6 @@
  */
 import api from '@/lib/api';
 import type {
-    WorkerLoginRequest,
-    WorkerLoginResponse,
     WorkerInfo,
     OperatorDashboard,
     ManagerOverview,
@@ -15,14 +13,6 @@ import type {
 } from '@/types/types';
 
 const BASE_PATH = '/workers';
-
-/**
- * Worker login (operator or manager)
- */
-export async function login(credentials: WorkerLoginRequest): Promise<WorkerLoginResponse> {
-    const response = await api.post<WorkerLoginResponse>(`${BASE_PATH}/login`, credentials);
-    return response.data;
-}
 
 /**
  * List all operators

--- a/intelligent-logistics-frontend/src/types/types.ts
+++ b/intelligent-logistics-frontend/src/types/types.ts
@@ -5,7 +5,10 @@
 
 // ==================== ENUMS ====================
 
-export type AppointmentStatusEnum = 'scheduled' | 'in_transit' | 'in_process' | 'unloading' | 'canceled' | 'delayed' | 'completed';
+// Primary flow states stored in DB (never 'delayed' or 'unloading')
+export type PrimaryAppointmentStatus = 'scheduled' | 'in_transit' | 'in_process' | 'canceled' | 'completed';
+// Display status includes computed sub-states for backward compat
+export type AppointmentStatusEnum = PrimaryAppointmentStatus | 'unloading' | 'delayed';
 export type DeliveryStatusEnum = 'not_started' | 'unloading' | 'completed';
 export type ShiftTypeEnum = '06:00-14:00' | '14:00-22:00' | '22:00-06:00';
 export type DirectionEnum = 'inbound' | 'outbound';
@@ -92,7 +95,11 @@ export interface Appointment {
     gate_out_id?: number | null;
     scheduled_start_time?: string | null;
     expected_duration?: number | null;
-    status: AppointmentStatusEnum;
+    status: AppointmentStatusEnum;       // display_status (compat) — may be 'delayed'/'unloading'
+    display_status?: AppointmentStatusEnum;
+    primary_status?: PrimaryAppointmentStatus; // raw DB state, never 'delayed'/'unloading'
+    is_delayed?: boolean;
+    is_unloading?: boolean;
     notes?: string | null;
     highway_infraction?: boolean;
     booking?: Booking | null;


### PR DESCRIPTION
This pull request makes a small change to the `workers.ts` service by removing the worker login functionality. The related types and the `login` function have been deleted, likely as part of a refactor or deprecation.

- Removed worker login types and the `login` function from `intelligent-logistics-frontend/src/services/workers.ts` [[1]](diffhunk://#diff-bd6e8cd1601adbe2f4323758d32fbd7a15c0779a75bec08fe22795db4a5b77fdL7-L8) [[2]](diffhunk://#diff-bd6e8cd1601adbe2f4323758d32fbd7a15c0779a75bec08fe22795db4a5b77fdL19-L26)